### PR TITLE
Add weak and normal strength to observables 

### DIFF
--- a/src/autorun.ts
+++ b/src/autorun.ts
@@ -57,6 +57,10 @@ export const run = <T>(fn: Cb<T>): Observable<T> => new Observable(observer => {
         if (hasError) {
             return throwError(error);
         }
+        // Mark all deps as untracked
+        for (let dep of deps.values()) {
+            dep.track = false;
+        }
         const prev$ = context.$;
         const prev_ = context._;
         context.$ = $;
@@ -136,7 +140,7 @@ export const run = <T>(fn: Cb<T>): Observable<T> => new Observable(observer => {
                         v.value = value;
 
                         if (isAsync) {
-                            if (track) {
+                            if (v.track) {
                                 update$.next(Update.Value);
                             } else {
                                 // NOTE: what to do if the silenced value is absent?

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -119,6 +119,28 @@ describe('autorun', () => {
         expect(observer.next.mock.calls).toEqual([['c']]);
     });
 
+    it('will not accept running $ and _ outside run', () => {
+        // Before run
+        const e = new Error('$ or _ can only be called within a run() context');
+        expect($).toThrow(e);
+        expect(_).toThrow(e);
+        expect($.weak).toThrow(e);
+        expect(_.normal).toThrow(e);
+        expect($.weak).toThrow(e);
+        expect(_.normal).toThrow(e);
+
+        const r = run(() => $(of(1)));
+        sub = r.subscribe(observer);
+
+        // After run
+        expect($).toThrow(e);
+        expect(_).toThrow(e);
+        expect($.weak).toThrow(e);
+        expect(_.normal).toThrow(e);
+        expect($.weak).toThrow(e);
+        expect(_.normal).toThrow(e);
+    });
+
     describe('completion', () => {
         it('will complete when deps complete', () => {
             const o = new BehaviorSubject(1);


### PR DESCRIPTION
It will now only mark an observable 'tracked' when it was used as such in the last run of the expression. This would (maybe partly?) fix #8.
Also it would unsubscribe an observable when it is not used any longer in the last run of the expression. This would (maybe partly?) fix #7.

We might want to update the semantics later to e.g., somehow mark observables as 'strong' so they will never be unsubscribed, and also won't 'suffer' from 'late subscription' and 'midflight interrupt'. This however requires API changes that are under discussion in #7.