### PR TITLE
Completing with EMPTY

### DIFF
--- a/src/autorun.ts
+++ b/src/autorun.ts
@@ -222,6 +222,19 @@ export const computed = <T>(fn: Expression<T>): Observable<T> => new Observable<
                     },
                     complete() {
                         v.completed = true;
+
+                        // if we don't have a value — we interrupt evaluation
+                        // and complete output. See issue #22
+                        if (!v.hasValue) {
+                            observer.complete();
+
+                            // immediately halt the computation
+                            if (!isAsync) {
+                                hasSyncError = true;
+                                syncError = HALT_ERROR;
+                            }
+                        }
+
                         if (isAsync && v.track) {
                             checkCompletion();
                         }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, defer, Observable, of, Subject, Subscription, throwError } from 'rxjs';
+import { BehaviorSubject, defer, NEVER, Observable, of, Subject, Subscription, throwError } from 'rxjs';
 import { $, computed, _ } from '../src';
 
 describe('autorun', () => {
@@ -701,6 +701,31 @@ describe('autorun', () => {
                 expect(isO2Subscribed).toBeFalsy();
             });
         });
+
+        describe('NEVER', () => {
+            it('basic filter', () => {
+                const o = new Subject<boolean>();
+                let i = 0;
+                const r = computed(() => $(o) ? i++ : $(NEVER));
+                sub = r.subscribe(observer);
+                expect(observer.next).not.toHaveBeenCalled();
+
+                // ok path
+                o.next(true);
+                expect(observer.next).toHaveBeenCalledWith(0);
+
+                // NEVER path
+                observer.next.mockClear();
+                o.next(false);
+                expect(observer.next).not.toHaveBeenCalled();
+
+                // ok again
+                observer.next.mockClear();
+                o.next(true);
+                expect(observer.next).toHaveBeenCalledWith(1);
+            });
+        });
+
     });
 
     describe('untracked with late emission', () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -834,23 +834,6 @@ describe('autorun', () => {
             expect(observer.complete).toBeCalled();
         });
 
-        // NOTE: THIS SCENARIO DOESN'T WORK NOW
-        xit('will not complete when untracked value completes before it emits when tracking other value', () => {
-            const o = new Subject<number>();
-            const o2 = new BehaviorSubject(2);
-            const r = computed(() => $(o2) + _(o));
-            sub = r.subscribe(observer);
-
-            expect(observer.next).not.toBeCalled();
-            expect(observer.complete).not.toBeCalled();
-
-            // o completes before it emits.
-            // expression will not complete yet because it might be that a new value of o2
-            // will branch around o.
-            o.complete();
-            expect(observer.next).not.toBeCalled();
-            expect(observer.complete).not.toBeCalled();
-        });
     });
 
 


### PR DESCRIPTION
fix #22 

This PR adds an ability to complete expression by tracking `EMPTY` observable. Thus we can implement a `takeWhile`:

```ts
computed(() => $(o) < 5 ? $(o) : $(EMPTY))
```